### PR TITLE
Fix the issue of generating incorrect GPT backup

### DIFF
--- a/NxNandManager/gui/NxNandManager.pro
+++ b/NxNandManager/gui/NxNandManager.pro
@@ -114,19 +114,20 @@ HEADERS += \
     dump.h \
     progress.h \
     emunand.h \
-    ../lib/ZipLib/*.h \
-    ../lib/ZipLib/utils/*.h \
-    ../lib/ZipLib/detail/*.h \
-    ../lib/ZipLib/extlibs/bzip2/*.h \
-    ../lib/ZipLib/extlibs/lzma/*.h \
+    $$files(../lib/ZipLib/*.h, false) \
+    $$files(../lib/ZipLib/utils/*.h, false) \
+    $$files(../lib/ZipLib/detail/*.h, false) \
+    $$files(../lib/ZipLib/extlibs/bzip2/*.h, false) \
+    $$files(../lib/ZipLib/extlibs/lzma/*.h, false) \
     debug.h
 
 CONFIG(STATIC) {
-    HEADERS -= ../lib/ZipLib/extlibs/zlib/zconf.h
+    SOURCES += $$files(../lib/ZipLib/extlibs/zlib/*.c, false)
+    HEADERS += $$files(../lib/ZipLib/extlibs/zlib/*.h)
 }
 CONFIG(DYNAMIC) {
     SOURCES += $$files(../lib/ZipLib/extlibs/zlib/*.c, false)
-    HEADERS += ../lib/ZipLib/extlibs/zlib/*.h \
+    HEADERS += $$files(../lib/ZipLib/extlibs/zlib/*.h)
 }
 
 FORMS += \
@@ -158,14 +159,14 @@ RC_FILE = NxNandManager.rc
 CONFIG(ARCH32) {
     DEFINES += ARCH32
     #OPENSSL PATH
-    OPENSSL_LIB_PATH = $$PWD/../../../../../mingw32
+    OPENSSL_LIB_PATH = $$PWD/../../../OpenSSL_mingw32
     LIBS += -L$$PWD/../virtual_fs/dokan/x86/lib/ -ldokan1
 
 }
 CONFIG(ARCH64) {
     DEFINES += ARCH64
     #OPENSSL PATH
-    OPENSSL_LIB_PATH = $$PWD/../../../../../mingw64
+    OPENSSL_LIB_PATH = $$PWD/../../../OpenSSL_mingw64
     LIBS += -L$$PWD/../virtual_fs/dokan/x64/lib/ -ldokan1
 }
 

--- a/NxNandManager/gui/mainwindow.ui
+++ b/NxNandManager/gui/mainwindow.ui
@@ -26,7 +26,7 @@
    <enum>Qt::NoFocus</enum>
   </property>
   <property name="windowTitle">
-   <string> NxNandManager v5.2 by eliboa</string>
+   <string> NxNandManager v5.2.1 by eliboa</string>
   </property>
   <property name="windowIcon">
    <iconset resource="application.qrc">

--- a/NxNandManager/lib/fatfs/ff.h
+++ b/NxNandManager/lib/fatfs/ff.h
@@ -101,9 +101,15 @@ typedef DWORD TCHAR;
 #elif FF_USE_LFN && (FF_LFN_UNICODE < 0 || FF_LFN_UNICODE > 3)
 #error Wrong FF_LFN_UNICODE setting
 #else									/* ANSI/OEM code in SBCS/DBCS */
-//typedef char TCHAR;
+#ifndef _TCHAR_DEFINED
+typedef char TCHAR;
+#endif
+#ifndef _T
 #define _T(x) x
+#endif
+#ifndef _TEXT
 #define _TEXT(x) x
+#endif
 #endif
 
 

--- a/NxNandManager/main.cpp
+++ b/NxNandManager/main.cpp
@@ -194,7 +194,7 @@ int main(int argc, char *argv[])
     //std::setlocale(LC_ALL, "en_US.utf8");
     std::setlocale(LC_ALL, "");
     std::locale::global(std::locale(""));
-    printf("[ NxNandManager v5.2 by eliboa ]\n\n");
+    printf("[ NxNandManager v5.2.1 by eliboa ]\n\n");
     const char *input = nullptr, *output = nullptr, *partitions = nullptr, *keyset = nullptr, *user_resize = nullptr, *boot0 = nullptr, *boot1 = nullptr, *std_redir_output = nullptr;
     wchar_t driveLetter = L'\0';
     BOOL dokan_install = false, info = false, gui = false, setAutoRCM = false, autoRCM = false, decrypt = false, encrypt = false;


### PR DESCRIPTION
Hello dear author! I have noticed an issue with this tool, where when I use it to resize the USER partition, the GPT backup it generates is incorrect. The partition table entries are still the same, including the LBA_END parameter of the USER partition. The GPT header backup is also incorrect. MY_LBA and ALT_LBA need to be swapped, and PARTITION_ENTRIES_LBA should be set to MY_LBA-32. Additionally, the CRC32 hash of the GPT header backup needs to be recomputed.
The reason why I found this problem is because I encountered an error when opening the virtual disk file RAWNAND.bin using DiskGenius. Later, I opened RAWNAND.bin with WinHex and analyzed the GPT backup, finally identifying the cause of the problem.
Later, I found the source code of this project on GitHub and fixed the issue. This pull request is intended to fix this issue. Please review it.